### PR TITLE
Task/fix type definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ function reducer(state, action) {
   }
 }
 
-const [state, dispatch] = (
+const [state, dispatch] = useReducer(
   process.env.NODE_ENV === 'development' ? logger(reducer) : reducer,
   initialState
 );

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 declare module "use-reducer-logger" {
     type Reducer<State = any, Action = any> = (state: State, action: Action) => State;
-    const logger = <State>(reducer: Reducer<State, Action>): Reducer<State, Action> => Reducer;
-    export default logger
+    const logger: <R extends Reducer>(reducer: R) => R;
+    export default logger;
 }


### PR DESCRIPTION
The type definitions for this package throw an error:

> node_modules/use-reducer-logger/index.d.ts(3,20): error TS1254: A 'const' initializer in an ambient context must be a string or numeric literal or literal enum reference.

Also, the dispatch type is incorrect. I came up with an example to show case two problems here: [TypeScript Playground](https://www.typescriptlang.org/play?ts=4.0.2#code/JYWwDg9gTgLgBAJQKYEMDGMA0cDecCuAzksgCb5pJRwC+cAZlBCHAORSoasDcAUKJFhwANhADmYqgyYtWRJAFoO5SlAWiJVHr14wAnmCSIkKqgB4AyjBQwk2AIIZgEAHYA+OAF44ACkLXbAC44Kxs7OHQYZxdgxyjXAEovD1DbPlIkNGEUDjg0V38GYAAPEwAZcUkoYLMEOCRi2xdSQmNTKDMUFz1sLr03Nx9lCipghCTPDwQ+fhdbKHp0IwBRYpRwYSRUoxxeOH24DhRSV2E9PIh8OeCXfBAAIyo+Gh0kW5ZV9bBNuOiAFQMOz2B2ALjQHBAb3g3lYoPBSEhc1YmGB+wy8MR0LY6IhUORvBes3mi0ocE+GyQv1cuFRh1QJxcZzg+kMwXJ30pTlcAMMfAOdOOp3OADcUMJ8EgbndHlBnjp6FcuS56msKWQRlA-AFJWTVRztr0lWy9T8lQljV9NtsafzCAB3YAwNAAC18kWiADoWUgkrt+fy0ChiLrLZz4i4eUgPXDcddaf6DhwYPgoMq-QmM-t8lcYMF-GEPdm5nAANQRJUe0XiuzxjM0PkZwPB9mm8ORj04hFQwK1hNJlNp3uZi45vPawuXYsKcvhytiiUo4cHF78l6EhVg8NwE74e6bHxViVSh5Uc1wd4ym2JpDJ1NwQ9GABUcAATHLeA1BPAN0qQxSAMLMJALhQj4vq0vkLiFAA2g+2CkMAhBgDYLoACKXHuSAALpeAQxDqqoPgaFUPg7phCTYC+CQNlmBTwNB+a2PBiHIU6zo4d48gEVQRGVDxDShtxUAUVeCZFrmcAAAyLsu1E6Py-Z3mYCHCm4Q7KcAqlDvygGjrgjFRuJK5LnAZj3PgMAwNSrj-sIwBoAA1p4OBgck24sShzo+Hg3oWhSVIRoC0ZgrGWBwKCVbAKQAAKTCGLAejBAARBFYpRUltAJDQbgAJIhagxBmAA9OZlmuGpmbFSpFUZhpWkmXAABq846jgD7GUuZkWVZyo2XZjnOa5kzuUhnnobu+5ZW442YcVpU9TVCZVZpi2mUV1Xvp+0DfoqW4tkggHgK4UIAOqOs6ABiJTlHxmrgQGdFwLBLXMaNbEzZsHF4SQJgaj49DXaQFSaJqZGbCJVE0RcUH0QZr2sS6X1cb9hEA6UQO3T4Alqijp7YOmYmThJ0m0jQcm0opyp1at-LU9pBy6dc+njkZ9P7F1ZW9S4tn2U5LkTB4CFvS63nMoCfkcgF7Yxl2czYKldkxXFVD6MlCvpZl2V5fCQZIHN3Xlep60rep1Vs01LXBG1LUdcOHM9XAfW84NAsjQjzofUgYHZZ7+uczTBzLfVgfG6pcpAA).

It shows that calling the dispatch function without any argument is not allowed by the type, which is allowed by React. Furthermore, the returned type for dispatch is too loose and does not check the action attributes properly.

I also added a call to `useReducer` in the example in the README, which I think was missing.